### PR TITLE
ci: reorder deployment steps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,14 +41,6 @@ jobs:
       - name: Build
         run: npm run build
 
-        # source: https://github.com/tschaub/gh-pages/issues/345#issuecomment-608243163
-      - name: Deploy site
-        run: |
-          git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-          npm run deploy -- -u "$GITHUB_ACTOR@users.noreply.github.com"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Release
         if: "!contains(github.event.head_commit.message, 'norelease')"
         run: npm run version
@@ -60,6 +52,14 @@ jobs:
         run: npm run publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # source: https://github.com/tschaub/gh-pages/issues/345#issuecomment-608243163
+      - name: Deploy site
+        run: |
+          git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          npm run deploy -- -u "$GITHUB_ACTOR@users.noreply.github.com"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       #
       # - name: Setup (GH package registry)
       #   uses: actions/setup-node@v1


### PR DESCRIPTION
put site deployment after release and publish, so docs are only updated when release completes