### PR TITLE
Feat/stable funcs

### DIFF
--- a/packages/react-cooked-bread/src/active-toasts-hook.ts
+++ b/packages/react-cooked-bread/src/active-toasts-hook.ts
@@ -3,13 +3,12 @@ import { useState, useCallback } from 'react'
 import { ActiveToast, Id, AddToastOptions, UpdateToastOptions } from './types'
 import { getId } from './utils'
 
-const checkForId = (id: string) => (t: ActiveToast) => t.id === id
-
-export const useActiveToasts = (maxToasts?: number | undefined) => {
+export const useActiveToasts = (_maxToasts?: number | undefined) => {
   const [toasts, setToasts] = useState<ActiveToast[]>([])
   const hasToasts = !!toasts.length
+  const maxToasts = Math.max(Number(_maxToasts), 0)
 
-  const exists = useCallback((id: Id) => toasts.some(checkForId(id)), [toasts])
+  const exists = useCallback((id: Id) => toasts.some((t: ActiveToast) => t.id === id), [toasts])
 
   const removeToast = useCallback(
     (id: Id) => {
@@ -36,12 +35,8 @@ export const useActiveToasts = (maxToasts?: number | undefined) => {
         const { type = 'info', ...rest } = options
         const newToast = { content, id, type, ...rest }
         setToasts((prevToasts) => {
-          if (typeof maxToasts === 'number' && maxToasts < prevToasts.length + 1) {
-            if (maxToasts > 0) {
-              return [...prevToasts.slice(1), newToast]
-            } else {
-              return []
-            }
+          if (maxToasts && maxToasts < toasts.length + 1) {
+            return [...prevToasts, newToast].slice(prevToasts.length + 1 - maxToasts)
           } else {
             return [...prevToasts, newToast]
           }
@@ -58,7 +53,7 @@ export const useActiveToasts = (maxToasts?: number | undefined) => {
     (id: Id, options: UpdateToastOptions = {}) => {
       if (exists(id)) {
         setToasts((prevToasts) => {
-          const index = prevToasts.findIndex(checkForId(id))
+          const index = prevToasts.findIndex((t: ActiveToast) => t.id === id)
           const updatedToast = { ...prevToasts[index], ...options }
           prevToasts.splice(index, 1, updatedToast)
           return prevToasts

--- a/packages/react-cooked-bread/src/active-toasts-hook.ts
+++ b/packages/react-cooked-bread/src/active-toasts-hook.ts
@@ -14,7 +14,7 @@ export const useActiveToasts = (maxToasts?: number | undefined) => {
   const removeToast = useCallback(
     (id: Id) => {
       if (exists(id)) {
-        setToasts((t) => t.filter((toast) => toast.id !== id))
+        setToasts((prevToasts) => prevToasts.filter((t) => t.id !== id))
       }
     },
     [exists]
@@ -35,21 +35,20 @@ export const useActiveToasts = (maxToasts?: number | undefined) => {
       if (id && !exists(id)) {
         const { type = 'info', ...rest } = options
         const newToast = { content, id, type, ...rest }
-        setToasts((t) => {
-          if (typeof maxToasts === 'number' && maxToasts < t.length + 1) {
+        setToasts((prevToasts) => {
+          if (typeof maxToasts === 'number' && maxToasts < prevToasts.length + 1) {
             if (maxToasts > 0) {
-              return [...t.slice(1), newToast]
+              return [...prevToasts.slice(1), newToast]
             } else {
               return []
             }
           } else {
-            return [...t, newToast]
+            return [...prevToasts, newToast]
           }
         })
         return id
       } else {
-        const i = getId()
-        return addToast(content, { ...options, id: i })
+        return addToast(content, { ...options, id: getId() })
       }
     },
     [exists, maxToasts]
@@ -58,11 +57,11 @@ export const useActiveToasts = (maxToasts?: number | undefined) => {
   const updateToast = useCallback(
     (id: Id, options: UpdateToastOptions = {}) => {
       if (exists(id)) {
-        setToasts((t) => {
-          const index = t.findIndex(checkForId(id))
-          const updatedToast = { ...t[index], ...options }
-          t.splice(index, 1, updatedToast)
-          return t
+        setToasts((prevToasts) => {
+          const index = prevToasts.findIndex(checkForId(id))
+          const updatedToast = { ...prevToasts[index], ...options }
+          prevToasts.splice(index, 1, updatedToast)
+          return prevToasts
         })
       }
     },

--- a/packages/react-cooked-bread/src/active-toasts-hook.ts
+++ b/packages/react-cooked-bread/src/active-toasts-hook.ts
@@ -3,65 +3,74 @@ import { useState, useCallback } from 'react'
 import { ActiveToast, Id, AddToastOptions, UpdateToastOptions } from './types'
 import { getId } from './utils'
 
+const checkForId = (id: string) => (t: ActiveToast) => t.id === id
+
 export const useActiveToasts = (maxToasts: number | undefined) => {
   const [toasts, setToasts] = useState<ActiveToast[]>([])
   const hasToasts = !!toasts.length
 
-  const exists = (id: Id) => {
-    if (id && hasToasts) {
-      return !!toasts.filter((t) => t.id === id).length
-    }
-  }
+  const exists = useCallback((id: Id) => toasts.some(checkForId(id)), [toasts])
 
-  const removeToast = (id: Id) => {
-    if (exists(id)) {
-      setToasts((prevToasts) => prevToasts.filter((t) => t.id !== id))
-    }
-  }
+  const removeToast = useCallback(
+    (id: Id) => {
+      if (exists(id)) {
+        setToasts((t) => t.filter((toast) => toast.id !== id))
+      }
+    },
+    [exists]
+  )
 
   const removeAllToasts = useCallback(() => {
     setToasts([])
   }, [])
+
+  const updateToast = useCallback(
+    (id: Id, options: UpdateToastOptions = {}) => {
+      if (exists(id)) {
+        setToasts((t) => {
+          const index = t.findIndex(checkForId(id))
+          const updatedToast = { ...t[index], ...options }
+          t.splice(index, 1, updatedToast)
+          return t
+        })
+      }
+    },
+    [exists]
+  )
 
   /**
    * @todo It's very convenient to guarantee a string return,
    * but we should configure this to gracefully fail creation
    * when a duplicate custom `id` is set in options
    */
-  const addToast = (content: React.ReactNode, options: AddToastOptions = {}): string => {
-    const id = options.id || getId()
-    if (!exists(id)) {
-      const { type = 'info', ...rest } = options
-      const newToast = { content, id, type, ...rest }
-      if (maxToasts && maxToasts < toasts.length + 1) {
-        setToasts((prevToasts) => [...prevToasts, newToast].slice(toasts.length + 1 - maxToasts))
+  const addToast = useCallback(
+    (content: React.ReactNode, options: AddToastOptions = {}): string => {
+      const id = options.id
+      if (id && !exists(id)) {
+        const { type = 'info', ...rest } = options
+        const newToast = { content, id, type, ...rest }
+        setToasts((t) => {
+          if (maxToasts && maxToasts < t.length + 1) {
+            return [...t.slice(1), newToast]
+          } else {
+            return [...t, newToast]
+          }
+        })
+        return id
       } else {
-        setToasts((prevToasts) => [...prevToasts, newToast])
+        const i = getId()
+        return addToast(content, { ...options, id: i })
       }
-      return id
-    } else {
-      return addToast(content, { ...options, id: getId() })
-    }
-  }
-
-  const updateToast = (id: Id, options: UpdateToastOptions = {}) => {
-    if (exists(id)) {
-      const index = toasts.findIndex((t) => t.id === id)
-      const updatedToast = { ...toasts[index], ...options }
-      setToasts((prevToasts) => [
-        ...prevToasts.slice(0, index),
-        updatedToast,
-        ...prevToasts.slice(index + 1),
-      ])
-    }
-  }
+    },
+    [exists, maxToasts]
+  )
 
   return {
-    toasts,
     addToast,
-    removeToast,
-    removeAllToasts,
-    updateToast,
     hasToasts,
+    removeAllToasts,
+    removeToast,
+    toasts,
+    updateToast,
   }
 }

--- a/packages/react-cooked-bread/src/active-toasts-hook.ts
+++ b/packages/react-cooked-bread/src/active-toasts-hook.ts
@@ -8,7 +8,7 @@ export const useActiveToasts = (_maxToasts?: number | undefined) => {
   const hasToasts = !!toasts.length
   const maxToasts = Math.max(Number(_maxToasts), 0)
 
-  const exists = useCallback((id: Id) => toasts.some((t: ActiveToast) => t.id === id), [toasts])
+  const exists = useCallback((id: Id) => toasts.some((t) => t.id === id), [toasts])
 
   const removeToast = useCallback(
     (id: Id) => {
@@ -35,7 +35,7 @@ export const useActiveToasts = (_maxToasts?: number | undefined) => {
         const { type = 'info', ...rest } = options
         const newToast = { content, id, type, ...rest }
         setToasts((prevToasts) => {
-          if (maxToasts && maxToasts < toasts.length + 1) {
+          if (maxToasts && maxToasts < prevToasts.length + 1) {
             return [...prevToasts, newToast].slice(prevToasts.length + 1 - maxToasts)
           } else {
             return [...prevToasts, newToast]
@@ -53,7 +53,7 @@ export const useActiveToasts = (_maxToasts?: number | undefined) => {
     (id: Id, options: UpdateToastOptions = {}) => {
       if (exists(id)) {
         setToasts((prevToasts) => {
-          const index = prevToasts.findIndex((t: ActiveToast) => t.id === id)
+          const index = prevToasts.findIndex((t) => t.id === id)
           const updatedToast = { ...prevToasts[index], ...options }
           prevToasts.splice(index, 1, updatedToast)
           return prevToasts

--- a/packages/react-cooked-bread/src/active-toasts-hook.ts
+++ b/packages/react-cooked-bread/src/active-toasts-hook.ts
@@ -24,20 +24,6 @@ export const useActiveToasts = (maxToasts: number | undefined) => {
     setToasts([])
   }, [])
 
-  const updateToast = useCallback(
-    (id: Id, options: UpdateToastOptions = {}) => {
-      if (exists(id)) {
-        setToasts((t) => {
-          const index = t.findIndex(checkForId(id))
-          const updatedToast = { ...t[index], ...options }
-          t.splice(index, 1, updatedToast)
-          return t
-        })
-      }
-    },
-    [exists]
-  )
-
   /**
    * @todo It's very convenient to guarantee a string return,
    * but we should configure this to gracefully fail creation
@@ -63,6 +49,20 @@ export const useActiveToasts = (maxToasts: number | undefined) => {
       }
     },
     [exists, maxToasts]
+  )
+
+  const updateToast = useCallback(
+    (id: Id, options: UpdateToastOptions = {}) => {
+      if (exists(id)) {
+        setToasts((t) => {
+          const index = t.findIndex(checkForId(id))
+          const updatedToast = { ...t[index], ...options }
+          t.splice(index, 1, updatedToast)
+          return t
+        })
+      }
+    },
+    [exists]
   )
 
   return {

--- a/packages/react-cooked-bread/src/active-toasts-hook.ts
+++ b/packages/react-cooked-bread/src/active-toasts-hook.ts
@@ -5,7 +5,7 @@ import { getId } from './utils'
 
 const checkForId = (id: string) => (t: ActiveToast) => t.id === id
 
-export const useActiveToasts = (maxToasts: number | undefined) => {
+export const useActiveToasts = (maxToasts?: number | undefined) => {
   const [toasts, setToasts] = useState<ActiveToast[]>([])
   const hasToasts = !!toasts.length
 
@@ -36,8 +36,12 @@ export const useActiveToasts = (maxToasts: number | undefined) => {
         const { type = 'info', ...rest } = options
         const newToast = { content, id, type, ...rest }
         setToasts((t) => {
-          if (maxToasts && maxToasts < t.length + 1) {
-            return [...t.slice(1), newToast]
+          if (typeof maxToasts === 'number' && maxToasts < t.length + 1) {
+            if (maxToasts > 0) {
+              return [...t.slice(1), newToast]
+            } else {
+              return []
+            }
           } else {
             return [...t, newToast]
           }

--- a/packages/react-cooked-bread/test/active-toasts-hook.test.ts
+++ b/packages/react-cooked-bread/test/active-toasts-hook.test.ts
@@ -122,6 +122,8 @@ describe('useActiveToasts', () => {
     act(() => {
       result.current.addToast('Cheers!')
       result.current.addToast('Cheers?')
+    })
+    act(() => {
       result.current.addToast('Cheers again')
     })
 
@@ -143,21 +145,30 @@ describe('useActiveToasts', () => {
     `)
   })
 
-  it('should not add toasts if maxToasts <= 0', () => {
+  it('should allow adding toasts if maxToasts <= 0', () => {
     const { result } = renderHook(() => useActiveToasts(0))
     act(() => {
       result.current.addToast('Cheers!')
     })
 
-    expect(result.current.hasToasts).toBe(false)
-    expect(result.current.toasts.length).toBe(0)
+    expect(result.current.hasToasts).toBe(true)
+    expect(result.current.toasts.length).toBe(1)
+
     const { result: r2 } = renderHook(() => useActiveToasts(-1))
     act(() => {
       r2.current.addToast('Cheers!')
     })
 
-    expect(r2.current.hasToasts).toBe(false)
-    expect(r2.current.toasts.length).toBe(0)
+    expect(r2.current.hasToasts).toBe(true)
+    expect(r2.current.toasts.length).toBe(1)
+
+    const { result: r3 } = renderHook(() => useActiveToasts(NaN))
+    act(() => {
+      r3.current.addToast('Cheers!')
+    })
+
+    expect(r3.current.hasToasts).toBe(true)
+    expect(r3.current.toasts.length).toBe(1)
   })
 
   it('should prevent duplicate toasts with the same custom ID', () => {

--- a/packages/react-cooked-bread/test/active-toasts-hook.test.ts
+++ b/packages/react-cooked-bread/test/active-toasts-hook.test.ts
@@ -151,7 +151,7 @@ describe('useActiveToasts', () => {
 
     expect(result.current.hasToasts).toBe(false)
     expect(result.current.toasts.length).toBe(0)
-    const { result:r2 } = renderHook(() => useActiveToasts(-1))
+    const { result: r2 } = renderHook(() => useActiveToasts(-1))
     act(() => {
       r2.current.addToast('Cheers!')
     })

--- a/packages/react-cooked-bread/test/context.test.tsx
+++ b/packages/react-cooked-bread/test/context.test.tsx
@@ -10,12 +10,22 @@ import {
   WithToastContextProps,
   useToasts,
 } from '../src/context'
-import { noop, getId } from '../src/utils'
 import { ToastType } from '../src/types'
+const utils = require('../src/utils')
+const { noop } = jest.requireActual('../src/utils')
+
+let id: number = 1
+jest.mock('../src/utils')
+utils.getFocusEvents.mockImplementation(() => ({ bind: noop, unbind: noop }))
+utils.getId.mockImplementation(() => ++id)
+utils.getStylesMapCSS.mockImplementation(() => ({}))
 
 describe('ToastConsumer', () => {
   beforeAll(() => {
     setupPortals()
+  })
+  beforeEach(() => {
+    id = 1
   })
 
   test('has an empty/noop default values', () => {
@@ -44,7 +54,7 @@ describe('ToastConsumer', () => {
 
   test('shows values from provider', () => {
     const toast = {
-      id: getId(),
+      id: 'what',
       content: 'Cheers!',
       type: ToastType.INFO,
       autoDismiss: false,
@@ -77,7 +87,7 @@ describe('ToastConsumer', () => {
 
 test('withToastContext shows values from provider', () => {
   const toast = {
-    id: getId(),
+    id: 'what',
     content: 'Cheers!',
     type: ToastType.INFO,
     autoDismiss: false,
@@ -115,9 +125,9 @@ test('withToastContext shows values from provider', () => {
 
 test('useToasts hook returns empty/noop default values', () => {
   const { result } = renderHook(() => useToasts(), { wrapper: ProviderWrapper })
-
+  let toastId = ''
   act(() => {
-    const toastId = result.current.addToast('Cheers!')
+    toastId = result.current.addToast('Cheers!')
     result.current.updateToast(toastId, {
       content: 'Cheers?',
     })
@@ -127,4 +137,13 @@ test('useToasts hook returns empty/noop default values', () => {
   })
 
   expect(result.current.toasts.length).toBe(1)
+  expect(result.current.toasts).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "content": "Cheers again!",
+        "id": 3,
+        "type": "info",
+      },
+    ]
+  `)
 })

--- a/packages/react-cooked-bread/test/context.test.tsx
+++ b/packages/react-cooked-bread/test/context.test.tsx
@@ -17,7 +17,7 @@ const { noop } = jest.requireActual('../src/utils')
 let id: number = 1
 jest.mock('../src/utils')
 utils.getFocusEvents.mockImplementation(() => ({ bind: noop, unbind: noop }))
-utils.getId.mockImplementation(() => ++id)
+utils.getId.mockImplementation(() => String(++id))
 utils.getStylesMapCSS.mockImplementation(() => ({}))
 
 describe('ToastConsumer', () => {
@@ -92,9 +92,8 @@ describe('ToastConsumer', () => {
 
   test('useToasts hook returns empty/noop default values', () => {
     const { result } = renderHook(() => useToasts(), { wrapper: ProviderWrapper })
-    let toastId = ''
     act(() => {
-      toastId = result.current.addToast('Cheers!')
+      const toastId = result.current.addToast('Cheers!')
       result.current.updateToast(toastId, {
         content: 'Cheers?',
       })
@@ -105,14 +104,14 @@ describe('ToastConsumer', () => {
 
     expect(result.current.toasts.length).toBe(1)
     expect(result.current.toasts).toMatchInlineSnapshot(`
-    Array [
-      Object {
-        "content": "Cheers again!",
-        "id": 3,
-        "type": "info",
-      },
-    ]
-  `)
+      Array [
+        Object {
+          "content": "Cheers again!",
+          "id": "3",
+          "type": "info",
+        },
+      ]
+    `)
   })
 
   test('shows values from provider', () => {


### PR DESCRIPTION
* makes the functions returned from `useActiveToasts` more stable to prevent infinite/unnecessary renders
* moves some tests into their parent describe blocks
* fixed a bug when maxToasts <= 0
* updated tests to condense some `act` blocks
* updated tests to use `inlineSnapshot` to make some of the checks a bit simpler

best viewed without whitespace